### PR TITLE
Add custom SVG icons for public and non-public access courts

### DIFF
--- a/docs/img/map-pin-green.svg
+++ b/docs/img/map-pin-green.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="white" stroke="#28a745" stroke-width="1" stroke-linecap="round" stroke-linejoin="round" class="feather feather-map-pin">
+    <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"></path>
+    <circle cx="12" cy="10" r="3"></circle>
+</svg>

--- a/docs/img/map-pin-red.svg
+++ b/docs/img/map-pin-red.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="white" stroke="#CE6C47" stroke-width="1" stroke-linecap="round" stroke-linejoin="round" class="feather feather-map-pin">
+    <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"></path>
+    <circle cx="12" cy="10" r="3"></circle>
+</svg>

--- a/js/basketballCourts.js
+++ b/js/basketballCourts.js
@@ -92,6 +92,13 @@ function displayBasketballCourts(courts) {
             popupAnchor: [-3, -76],
         });
 
+        // Change marker depending on access
+        if (court.access === 'true') {
+            markerIcon.options.iconUrl = 'docs/img/map-pin-green.svg';
+        } else if (court.access === 'false') {
+            markerIcon.options.iconUrl = 'docs/img/map-pin-red.svg';
+        }
+
         // Add the marker to the map
         const marker = L.marker([court.latitude, court.longitude], { icon: markerIcon })
             .bindPopup(courtsContent)


### PR DESCRIPTION
### Summary

This pull request introduces custom SVG icons to distinguish between basketball courts with public access and those without. The markers are color-coded for better visual distinction on the map.

### Changes

- Added `map-pin-red.svg` for non-public access courts.
- Added `map-pin-green.svg` for public access courts.
- Updated `basketballCourts.js` to use the new SVG icons based on the court's access status.

### Details

- **map-pin-red.svg**: A red pin icon used for courts without public access.
- **map-pin-green.svg**: A green pin icon used for courts with public access.
- **basketballCourts.js**: Modified the `displayBasketballCourts` function to select the appropriate icon based on the court's access status.

### Testing

1. Verified that the markers are displayed correctly on the map.
2. Confirmed that the markers change color based on the court's access status.

### Screenshots

![Screenshot](https://balldontlie.fr/images/Screenshot%202024-10-17%20144815.png)

### Additional Notes

- Ensure that the SVG files are located in the `docs/img` directory.
- This change improves the user experience by providing a clear visual distinction between different types of courts.

### Related Issues

- Closes #<issue-number> (if applicable)

### Checklist

- [x] Tested the changes locally
- [x] Verified the functionality on different browsers